### PR TITLE
Fix markdown formatting of point 80 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Articles of **Common Knowledge Co-operative Ltd**.
 
 ### **Chairperson**
 
-80.Directors shall appoint one of their number as the chairperson to facilitate meetings of the Board of Directors. If they are absent or unwilling to act at the time any meeting proceeds to business then the Directors present shall choose one of their number to be the chairperson for that meeting. The appointment of a chairperson shall be the first item of business at the meeting.
+80. Directors shall appoint one of their number as the chairperson to facilitate meetings of the Board of Directors. If they are absent or unwilling to act at the time any meeting proceeds to business then the Directors present shall choose one of their number to be the chairperson for that meeting. The appointment of a chairperson shall be the first item of business at the meeting.
 
 ### **Declaration of Interest**
 


### PR DESCRIPTION
I have been reading your Articles of Association and noticed a small typo in the formatting of the markdown. 

This change adds a white space to point 80 - to allow it to be rendered as a numbered point. It has no bearing on the content of the document. 

I also just want to say thank you for making this document public!