### PR TITLE
Fix markdown formatting of point 82.b in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,9 +349,10 @@ Provided that nothing in this Article shall prevent a Director from counting tow
     a. In accordance with (but subject to) the Companies Acts, the Board of Directors may give authorisation in respect of a situation in which a Director has, or could have, a direct or indirect interest that conflicts, or possibly may conflict, with the interests of the Cooperative; and
 
     b. In authorising a situation the Board of Directors may decide, whether at the time of giving the authorisation or subsequently, that if the conflicted Director has obtained any information through their involvement in the situation otherwise that as a Director and in respect of which they owe a duty of confidentiality to another person, the Director is under no obligation to:
-        i. Disclose that information to the Cooperative; and/or
 
-       ii. Use that information for the benefit of the Cooperative;where to do so would amount to a breach of confidence
+      i. Disclose that information to the Cooperative; and/or
+
+      ii. Use that information for the benefit of the Cooperative;where to do so would amount to a breach of confidence
 
 ### **Expenses**
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Provided that nothing in this Article shall prevent a Director from counting tow
 
       i. Disclose that information to the Cooperative; and/or
 
-      ii. Use that information for the benefit of the Cooperative;where to do so would amount to a breach of confidence
+      ii. Use that information for the benefit of the Cooperative; where to do so would amount to a breach of confidence
 
 ### **Expenses**
 


### PR DESCRIPTION
This is another small whitespace change in order to display point `82.b` `i.` and `ii.` at the same level of the document.

### Before change:
<img width="860" alt="image" src="https://user-images.githubusercontent.com/12589522/200206953-00371201-1e67-4eb9-86bd-b8e9c592e0e0.png">


### After change:
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/12589522/200206881-0be7c79a-8a84-414c-b0ba-4b1fcbc5c263.png">

---
### Update:
I also noticed a small white space missing after looking at these screenshot - which I have added as an extra commit.